### PR TITLE
New stimulus/response representation

### DIFF
--- a/berp/config/dataset.py
+++ b/berp/config/dataset.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Dict, Optional
 
 import mne
 
@@ -11,6 +11,7 @@ GROUP = "dataset"
 @dataclass
 class DatasetConfig:
     paths: List[str]
+    stimulus_paths: Dict[str, str]
 
 
 @dataclass

--- a/berp/datasets/__init__.py
+++ b/berp/datasets/__init__.py
@@ -1,3 +1,159 @@
+from dataclasses import dataclass
+from functools import cached_property
+import logging
+from typing import List
+
+import torch
+from torchtyping import TensorType  # mypy: ignore
+
+from berp.typing import DIMS, is_probability, is_log_probability, is_positive
+
+L = logging.getLogger(__name__)
+
+
+# Type variables
+B, N_W, N_C, N_F, N_F_T, N_P, V_W = \
+    DIMS.B, DIMS.N_W, DIMS.N_C, DIMS.N_F, DIMS.N_F_T, DIMS.N_P, DIMS.V_W
+T, S = DIMS.T, DIMS.S
+
+
+# Type aliases
+Phoneme = str
+
+
+class Vocabulary(object):
+
+    def __init__(self):
+        self.tok2idx = {}
+        self.idx2tok = []
+
+    def __len__(self):
+        return len(self.idx2tok)
+    
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return self.idx2tok[key]
+        elif isinstance(key, str):
+            return self.tok2idx[key]
+        else:
+            raise TypeError(f"Invalid key type: {type(key)}")
+
+    def __contains__(self, key):
+        if isinstance(key, int):
+            return key < len(self.idx2tok)
+        elif isinstance(key, str):
+            return key in self.tok2idx
+        else:
+            raise TypeError(f"Invalid key type: {type(key)}")
+
+    def add(self, token: str):
+        if token not in self.tok2idx:
+            self.tok2idx[token] = len(self.idx2tok)
+            self.idx2tok.append(token)
+
+        return self.tok2idx[token]
+
+
+@dataclass
+class NaturalLanguageStimulus:
+    """
+    Describes the linguistic stimulus used in a trial, along with probabilistic model
+    outputs of counterfactual stimulus data. This data is shareable across subjects
+    who perceived the same data. Separately, BerpDataset represents the particular
+    presentation of a stimulus to a subject, along with recorded responses.
+    """
+
+    name: str
+
+    phonemes: List[Phoneme]
+    """
+    Phoneme vocabulary.
+    """
+
+    pad_phoneme_id: int
+    """
+    Index of padding phoneme in phoneme vocabulary.
+    """
+
+    word_ids: TensorType[N_W, torch.long]
+    """
+    For each row in the dataset, the ID of the corresponding word in the
+    source corpus.
+    """
+
+    word_lengths: TensorType[N_W, int]
+    """
+    Length of each ground-truth word in the dataset (in number of phonemes).
+    """
+
+    word_features: TensorType[N_W, N_F, float]
+    """
+    Arbitrary word-level features.
+    """
+
+    p_candidates: TensorType[N_W, N_C, torch.float, is_log_probability]
+    """
+    Prior predictive distribution over words at each timestep. Each
+    row is a proper log-e-probability distribution.
+    """
+
+    candidate_ids: TensorType[N_W, N_C, torch.long]
+    """
+    For each row in the dataset, the IDs of the top `N_C` candidates in the
+    candidate vocabulary.
+    """
+
+    candidate_vocabulary: Vocabulary
+    """
+    Vocabulary of candidate words referred to by `candidate_ids`.
+    """
+
+    @property
+    def max_n_phonemes(self):
+        return max(self.word_lengths)
+
+    @property
+    def word_surprisals(self) -> TensorType[N_W, torch.float, is_positive]:
+        """
+        Get surprisals of ground-truth words (in bits; log-2).
+        """
+        return -self.p_candidates[:, 0] / np.log(2)
+
+    @cached_property
+    def candidate_phonemes(self) -> TensorType[N_W, N_C, N_P, torch.long]:
+        """
+        For each candidate in each prior predictive, the corresponding
+        phoneme sequence. Sequences are padded with `pad_phoneme_id`.
+        """
+        # Compute phoneme sequences for all candidates.
+        candidate_phoneme_voc = torch.zeros(
+            (len(self.candidate_vocabulary), self.max_n_phonemes),
+            dtype=torch.long)
+        candidate_phoneme_voc.fill_(self.pad_phoneme_id)
+
+        phon2idx = {p: i for i, p in enumerate(self.phonemes)}
+        for i, candidate in enumerate(self.candidate_vocabulary):
+            phoneme_seq = torch.tensor([phon2idx[phon] for phon in candidate])
+            candidate_phoneme_voc[i, :len(phoneme_seq)] = phoneme_seq
+
+        reindexed = torch.index_select(candidate_phoneme_voc, 0,
+                                       self.candidate_ids.flatten())
+        reindexed = reindexed.reshape(*self.candidate_ids.shape, 14)
+        return reindexed
+
+    def get_candidate_strs(self, word_idx, top_k=None) -> List[str]:
+        """
+        Get string representations for the candidates of the given word.
+        """
+        candidate_phonemes = self.candidate_phonemes
+        phonemes = candidate_phonemes[word_idx]
+        if top_k is not None:
+            phonemes = phonemes[:top_k, :]
+        rets = ["".join(self.phonemes[phon_idx] for phon_idx in word
+                        if phon_idx != self.pad_phoneme_id)
+                for word in phonemes]
+        return rets
+
 from berp.datasets.processor import NaturalLanguageStimulusProcessor
 from berp.datasets.base import BerpDataset, NestedBerpDataset
 

--- a/berp/datasets/__init__.py
+++ b/berp/datasets/__init__.py
@@ -3,6 +3,7 @@ from functools import cached_property
 import logging
 from typing import List
 
+import numpy as np
 import torch
 from torchtyping import TensorType  # mypy: ignore
 
@@ -138,7 +139,8 @@ class NaturalLanguageStimulus:
 
         reindexed = torch.index_select(candidate_phoneme_voc, 0,
                                        self.candidate_ids.flatten())
-        reindexed = reindexed.reshape(*self.candidate_ids.shape, 14)
+        reindexed = reindexed.reshape(
+            *self.candidate_ids.shape, self.max_n_phonemes)
         return reindexed
 
     def get_candidate_strs(self, word_idx, top_k=None) -> List[str]:

--- a/berp/datasets/base.py
+++ b/berp/datasets/base.py
@@ -47,7 +47,7 @@ class BerpDataset:
     Phoneme vocabulary.
     """
 
-    p_word: TensorType[B, N_C, is_log_probability]
+    p_candidates: TensorType[B, N_C, is_log_probability]
     """
     Predictive distribution over expected candidate words at each time step,
     derived from a language model.
@@ -160,7 +160,7 @@ class BerpDataset:
         """
         Number of represented candidate completions for each context.
         """
-        return self.p_word.shape[1]
+        return self.p_candidates.shape[1]
     
     @property
     def phoneme_onsets_global(self) -> TensorType[B, N_P, float, is_positive]:
@@ -216,7 +216,7 @@ class BerpDataset:
             ret = dataclasses.replace(self,
                 name=f"{self.name}/slice:{start_sample}:{end_sample}",
 
-                p_word=self.p_word[keep_word_indices],
+                p_candidates=self.p_candidates[keep_word_indices],
                 word_lengths=self.word_lengths[keep_word_indices],
                 candidate_phonemes=self.candidate_phonemes[keep_word_indices],
 
@@ -239,7 +239,7 @@ class BerpDataset:
         """
         Check that all data arrays have the expected shape.
         """
-        assert self.p_word.shape == (self.n_words, self.n_candidates)
+        assert self.p_candidates.shape == (self.n_words, self.n_candidates)
         assert self.word_lengths.shape == (self.n_words,)
         assert self.candidate_phonemes.shape == (self.n_words, self.n_candidates, self.max_n_phonemes)
         assert self.word_onsets.shape == (self.n_words,)
@@ -257,7 +257,7 @@ class BerpDataset:
         """
         Convert all tensors to torch tensors.
         """
-        self.p_word = torch.as_tensor(self.p_word, dtype=torch.float32)
+        self.p_candidates = torch.as_tensor(self.p_candidates, dtype=torch.float32)
         self.word_lengths = torch.as_tensor(self.word_lengths)
         self.candidate_phonemes = torch.as_tensor(self.candidate_phonemes)
         self.word_onsets = torch.as_tensor(self.word_onsets, dtype=torch.float32)
@@ -435,7 +435,7 @@ def average_datasets(datasets: List[BerpDataset], name="average"):
         ds0 = datasets[0]
         assert_compatible(ds, ds0)
 
-        assert torch.allclose(ds.p_word, ds0.p_word)
+        assert torch.allclose(ds.p_candidates, ds0.p_candidates)
         assert torch.allclose(ds.word_lengths, ds0.word_lengths)
         assert torch.allclose(ds.candidate_phonemes, ds0.candidate_phonemes)
         assert torch.allclose(ds.word_onsets, ds0.word_onsets)

--- a/berp/generators/thresholded_recognition_simple.py
+++ b/berp/generators/thresholded_recognition_simple.py
@@ -103,10 +103,10 @@ def sample_dataset(params: rr.ModelParameters,
 
     ############
 
-    p_word_posterior = rr.predictive_model(stim.p_word, stim.candidate_phonemes,
+    p_candidates_posterior = rr.predictive_model(stim.p_candidates, stim.candidate_phonemes,
                                            confusion=params.confusion,
                                            lambda_=params.lambda_)
-    recognition_points = rr.recognition_point_model(p_word_posterior,
+    recognition_points = rr.recognition_point_model(p_candidates_posterior,
                                                     stim.word_lengths,
                                                     threshold=params.threshold)
     
@@ -140,7 +140,7 @@ def sample_dataset(params: rr.ModelParameters,
         sample_rate=sample_rate,
         phonemes=PHONEMES.tolist(),
 
-        p_word=stim.p_word,
+        p_candidates=stim.p_candidates,
         word_lengths=stim.word_lengths,
         candidate_phonemes=stim.candidate_phonemes,
 

--- a/berp/languages/dutch.py
+++ b/berp/languages/dutch.py
@@ -3,6 +3,7 @@ Defines data and utilities for Dutch processing.
 """
 
 from collections import Counter
+from functools import cache
 import logging
 import re
 from typing import List
@@ -204,6 +205,7 @@ class CelexPhonemizer:
         
         self.missing_counter = Counter()
         
+    @cache
     def __call__(self, string):
         if punct_only_re.match(string):
             return ""

--- a/berp/models/trf_em.py
+++ b/berp/models/trf_em.py
@@ -491,12 +491,12 @@ class GroupBerpTRFForwardPipeline(GroupTRFForwardPipeline):
                                ) -> TensorType[torch.long]:
         # TODO cache rec point computation?
         # profile and find out if it's worth it
-        p_word_posterior = predictive_model(
-            dataset.p_word, dataset.candidate_phonemes,
+        p_candidates_posterior = predictive_model(
+            dataset.p_candidates, dataset.candidate_phonemes,
             params.confusion, params.lambda_
         )
         recognition_points = recognition_point_model(
-            p_word_posterior, dataset.word_lengths, params.threshold
+            p_candidates_posterior, dataset.word_lengths, params.threshold
         )
         return recognition_points
 

--- a/flows/gillis2021.nf
+++ b/flows/gillis2021.nf
@@ -275,7 +275,7 @@ process fitBerpGrid {
 
     script:
     dataset_path_str = datasets.join(",")
-    
+
     // Produce stimulus lookup dict
     stimulus_path_str = stimuli.collect { "${it.baseName}:'${it}'" }.join(",")
     stimulus_path_str = "\"{${stimulus_path_str}}\""
@@ -284,6 +284,7 @@ process fitBerpGrid {
     python ${baseDir}/scripts/fit_em.py \
         model=trf-berp-fixed \
         'dataset.paths=[${dataset_path_str}]' \
+        +dataset.stimulus_paths=${stimulus_path_str} \
         model.confusion_path=${confusion} \
         cv=search_alpha_threshold \
         solver=adam \
@@ -401,6 +402,9 @@ workflow {
         average_dataset.collect { it[1] },
         nl_stimuli.collect { it[1] })
 
-    // // Fit Berp model on average dataset.
-    // fitBerpGrid(average_dataset.collect(), nl_stimuli.collect(), confusion)
+    // Fit Berp model on average dataset.
+    fitBerpGrid(
+        average_dataset.collect { it[1] },
+        nl_stimuli.collect { it[1] },
+        confusion)
 }

--- a/scripts/gillis2021/prepare_confusion.py
+++ b/scripts/gillis2021/prepare_confusion.py
@@ -19,6 +19,7 @@ import seaborn as sns
 # %load_ext autoreload
 # %autoreload 2
 
+from berp.datasets import NaturalLanguageStimulus
 from berp.languages.dutch import convert_to_smits_ipa, cgn_ipa_mapping
 
 IS_INTERACTIVE = False
@@ -102,7 +103,7 @@ if IS_INTERACTIVE:
     sns.heatmap(conf_df / conf_df.sum(axis=0))
 
 with open(args.dataset_path, "rb") as f:
-    dataset = pickle.load(f)
+    dataset: NaturalLanguageStimulus = pickle.load(f)
 
 # +
 # These phonemes are special in the dataset and we'll manually add them to the confusion matrix.

--- a/scripts/gillis2021/produce_dataset.py
+++ b/scripts/gillis2021/produce_dataset.py
@@ -58,6 +58,7 @@ story_name = args.natural_language_stimulus_path.stem
 
 with args.natural_language_stimulus_path.open("rb") as f:
     story_stim = pickle.load(f)
+assert story_stim.name == story_name
 ts_features_dict = np.load(args.stim_path)
 ts_feature_names = ts_features_dict["feature_names"].tolist()
 time_series_features = ts_features_dict[story_name]
@@ -151,12 +152,10 @@ phoneme_onsets = torch.stack([
 
 ret = BerpDataset(
     name=f"{story_name}/{subject}",
+    stimulus_name=story_stim.name,
     sample_rate=int(info["sfreq"]),
     
     phonemes=story_stim.phonemes,
-    p_candidates=story_stim.p_candidates,
-    word_lengths=story_stim.word_lengths,
-    candidate_phonemes=story_stim.candidate_phonemes,
     
     word_onsets=word_onsets,
     phoneme_onsets=phoneme_onsets,

--- a/scripts/gillis2021/produce_dataset.py
+++ b/scripts/gillis2021/produce_dataset.py
@@ -154,7 +154,7 @@ ret = BerpDataset(
     sample_rate=int(info["sfreq"]),
     
     phonemes=story_stim.phonemes,
-    p_word=story_stim.p_word,
+    p_candidates=story_stim.p_candidates,
     word_lengths=story_stim.word_lengths,
     candidate_phonemes=story_stim.candidate_phonemes,
     

--- a/scripts/gillis2021/run_language_model.py
+++ b/scripts/gillis2021/run_language_model.py
@@ -45,7 +45,7 @@ if IS_INTERACTIVE:
                      aligned_words_path=Path("DKZ_1.words.csv"),
                      aligned_phonemes_path=Path("DKZ_1.phonemes.csv"),
                      model="GroNLP/gpt2-small-dutch",
-                     n_candidates=1000,
+                     n_candidates=40000,
                      vocab_path=Path("../../data/gillis2021/vocab.pkl"),
                      celex_path=Path("../../data/gillis2021/celex_dpw_cx.txt"))
 else:
@@ -119,11 +119,13 @@ ground_truth_phonemes = {
 # Prepare word-level features.
 word_features = dict(words_df.groupby(["original_idx"])
                      .apply(lambda xs: torch.tensor(xs.iloc[0].frequency).unsqueeze(0)))
-
-stim = proc(tokens, word_to_token, word_features, ground_truth_phonemes)
 # -
 
+stim = proc(story_name, tokens, word_to_token, word_features, ground_truth_phonemes)
+
 celex_phonemizer.missing_counter.most_common(50)
+
+len(stim.candidate_vocabulary)
 
 with open(f"{story_name}.pkl", "wb") as f:
     pickle.dump(stim, f)

--- a/test/datasets/test_base.py
+++ b/test/datasets/test_base.py
@@ -29,7 +29,7 @@ def make_dataset():
         sample_rate=sfreq,
         phonemes=[chr(i) for i in range(stim_gen.num_phonemes)],
 
-        p_word=stim.p_word,
+        p_candidates=stim.p_candidates,
         word_lengths=stim.word_lengths,
         candidate_phonemes=stim.candidate_phonemes,
         word_onsets=stim.word_onsets,

--- a/test/models/test_reindexing_regression.py
+++ b/test/models/test_reindexing_regression.py
@@ -89,13 +89,13 @@ def soundness_dataset2(sentences):
 
 
 def model_forward(params, dataset):
-    p_word_posterior = rr.predictive_model(
-        dataset.p_word, dataset.candidate_phonemes,
+    p_candidates_posterior = rr.predictive_model(
+        dataset.p_candidates, dataset.candidate_phonemes,
         params.confusion, params.lambda_)
     rec_points = rr.recognition_point_model(
-        p_word_posterior, dataset.word_lengths, params.threshold
+        p_candidates_posterior, dataset.word_lengths, params.threshold
     )
-    return p_word_posterior, rec_points
+    return p_candidates_posterior, rec_points
 
 
 def test_recognition_logic(soundness_dataset1):


### PR DESCRIPTION
In order to support much larger candidate vocabularies and enable scaling to larger datasets, I've decoupled the previously coupled representation of

1. text stimulus representation and prior predictive over phoneme sequences, and
2. stimulus presentation data (e.g. timing information) and EEG response

These were formerly coupled in the pickled `BerpDataset` objects. Now we retain `NaturalLanguageStimulus` objects for the first, and use `BerpDataset` for the latter.

At pickle-time each `BerpDataset` retains a `stimulus_name` key pointing to its generating stimulus data, which is reloaded at next runtime.

At runtime a single `BerpDataset` is still used; none of the modeling code is touched. Simply call `BerpDataset.with_stimulus` to load in a relevant stimulus representation.