### PR TITLE
Parameterized recognition point scatter

### DIFF
--- a/berp/generators/thresholded_recognition_simple.py
+++ b/berp/generators/thresholded_recognition_simple.py
@@ -137,6 +137,7 @@ def sample_dataset(params: rr.ModelParameters,
 
     return BerpDataset(
         name=uuid.uuid4().hex,
+        stimulus_name=uuid.uuid4().hex,
         sample_rate=sample_rate,
         phonemes=PHONEMES.tolist(),
 
@@ -145,6 +146,7 @@ def sample_dataset(params: rr.ModelParameters,
         candidate_phonemes=stim.candidate_phonemes,
 
         word_onsets=stim.word_onsets,
+        word_offsets=stim.word_offsets,
         phoneme_onsets=stim.phoneme_onsets,
 
         Y=Y,

--- a/berp/models/trf_em.py
+++ b/berp/models/trf_em.py
@@ -583,13 +583,16 @@ class GroupBerpFixedTRFForwardPipeline(GroupBerpTRFForwardPipeline):
                  threshold: torch.Tensor,
                  confusion: torch.Tensor,
                  lambda_: torch.Tensor,
+                 recognition_scatter_point: float = 0,
                  **kwargs):
         params = PartiallyObservedModelParameters(
             threshold=threshold,
             confusion=confusion,
             lambda_=lambda_,
         )
-        super().__init__(encoder, [params], **kwargs)
+        super().__init__(encoder, [params],
+            recognition_scatter_point=recognition_scatter_point,
+            **kwargs)
 
         self.threshold = threshold
         self.confusion = confusion

--- a/conf/cv/search_alpha_threshold_lambda_scatter.yaml
+++ b/conf/cv/search_alpha_threshold_lambda_scatter.yaml
@@ -1,0 +1,32 @@
+n_outer_folds: 4
+n_inner_folds: 4
+n_trials: 100
+
+param_sampler:
+  _target_: optuna.samplers.TPESampler
+  multivariate: true
+
+params:
+  encoder__alpha:
+    type: float
+    low: 1e1
+    high: 1e6
+    log: true
+    # shape: [129]
+
+  threshold:
+    type: float
+    low: 0.0
+    high: 1.0
+
+  lambda_:
+    type: float
+    low: 0.1
+    high: 3
+
+  recognition_scatter_point:
+    type: categorical
+    choices:
+      - 0
+      - 0.5
+      - 1

--- a/flows/gillis2021.nf
+++ b/flows/gillis2021.nf
@@ -286,7 +286,7 @@ process fitBerpGrid {
         'dataset.paths=[${dataset_path_str}]' \
         +dataset.stimulus_paths=${stimulus_path_str} \
         model.confusion_path=${confusion} \
-        cv=search_alpha_threshold \
+        cv=search_alpha_threshold_lambda_scatter \
         solver=adam \
         hydra.run.dir="berp-fixed"
     """
@@ -398,9 +398,9 @@ workflow {
     full_datasets_by_story = full_datasets.map { [it[1], it[2]] }.groupTuple()
     average_dataset = produceAverageDataset(full_datasets_by_story)
 
-    vanilla = fitUnitaryVanillaEncoder(
-        average_dataset.collect { it[1] },
-        nl_stimuli.collect { it[1] })
+    // vanilla = fitUnitaryVanillaEncoder(
+    //     average_dataset.collect { it[1] },
+    //     nl_stimuli.collect { it[1] })
 
     // Fit Berp model on average dataset.
     fitBerpGrid(

--- a/scripts/gillis2021/produce_dataset.py
+++ b/scripts/gillis2021/produce_dataset.py
@@ -124,10 +124,13 @@ info = mne.create_info(ch_names=montage.ch_names,
 # Load EEG and trim to match time series features.
 eeg = load_eeg(args.eeg_path, info, trim_n_samples=X_ts.shape[0])
 
-# Retrieve onset information.
+# Retrieve word boundary information.
 word_onsets = words_df.groupby("original_idx").start.min().to_dict()
 word_onsets = torch.tensor([word_onsets[word_id.item()]
                             for word_id in story_stim.word_ids])
+word_offsets = words_df.groupby("original_idx").end.max().to_dict()
+word_offsets = torch.tensor([word_offsets[word_id.item()]
+                             for word_id in story_stim.word_ids])
 
 # +
 # Phoneme onsets.
@@ -158,6 +161,7 @@ ret = BerpDataset(
     phonemes=story_stim.phonemes,
     
     word_onsets=word_onsets,
+    word_offsets=word_offsets,
     phoneme_onsets=phoneme_onsets,
     
     X_ts=X_ts,

--- a/test/datasets/test_base.py
+++ b/test/datasets/test_base.py
@@ -26,6 +26,7 @@ def make_dataset():
 
     return BerpDataset(
         name=uuid.uuid4().hex,
+        stimulus_name=uuid.uuid4().hex,
         sample_rate=sfreq,
         phonemes=[chr(i) for i in range(stim_gen.num_phonemes)],
 
@@ -33,12 +34,21 @@ def make_dataset():
         word_lengths=stim.word_lengths,
         candidate_phonemes=stim.candidate_phonemes,
         word_onsets=stim.word_onsets,
+        word_offsets=stim.word_offsets,
         phoneme_onsets=stim.phoneme_onsets,
 
         X_ts=X_ts,
         X_variable=X_variable,
         Y=Y
     )
+
+
+def test_offsets():
+    ds = make_dataset()
+    assert ds.phoneme_offsets_global.shape == ds.phoneme_onsets_global.shape
+
+    assert torch.allclose(ds.phoneme_offsets_global[:, -1], ds.word_offsets)
+    assert (ds.word_offsets[:-1] <= ds.word_onsets[1:]).all(), "No overlapping words"
 
 
 def test_slice_name():


### PR DESCRIPTION
We formerly assumed that if a word was recognized at phoneme $p_i$ with onset $t_i$, then the word is recognized at point $t_i$. This is unrealistic.

Slightly more realistically: let $t_{i+1}$ be the offset of phoneme $p_i$. Then for a parameter $\phi$, we let the recognition time be
$$\phi t_i + (1 - \phi) t_{i+1}$$

So for $\phi = 0.5$ we assert that halfway through a trigger phoneme's onset/offset window, the word is recognized.