### PR TITLE
fix zero-padding mistakes in global phoneme onset/offsets; nail down …

### DIFF
--- a/berp/generators/thresholded_recognition_simple.py
+++ b/berp/generators/thresholded_recognition_simple.py
@@ -55,7 +55,7 @@ def response_model(stim: Stimulus,
     recognition_onsets_global_samp = time_to_sample(stim.word_onsets + recognition_onsets, sample_rate)
 
     # Generate continuous signal stream.
-    t_max = stim.phoneme_onsets_global[-1, -1] + right_padding
+    t_max = stim.word_offsets[-1] + right_padding
     Y = torch.normal(0, params.sigma,
                      size=(int(np.ceil(t_max * sample_rate)), num_sensors))
 

--- a/test/datasets/test_base.py
+++ b/test/datasets/test_base.py
@@ -47,12 +47,24 @@ def make_dataset():
     )
 
 
+def test_onsets_global():
+    ds = make_dataset()
+
+    assert ds.phoneme_onsets_global.shape == ds.phoneme_onsets.shape
+
+    # nonzero items should reflect word length
+    torch.testing.assert_close((ds.phoneme_onsets_global != 0).sum(1).long(), ds.word_lengths)
+
+
 def test_offsets():
     ds = make_dataset()
     assert ds.phoneme_offsets_global.shape == ds.phoneme_onsets_global.shape
 
-    assert torch.allclose(ds.phoneme_offsets_global[:, -1], ds.word_offsets)
+    assert torch.allclose(ds.phoneme_offsets_global.max(1)[0], ds.word_offsets)
     assert (ds.word_offsets[:-1] <= ds.word_onsets[1:]).all(), "No overlapping words"
+
+    torch.testing.assert_close((ds.phoneme_offsets != 0).sum(1).long(), ds.word_lengths)
+    torch.testing.assert_close((ds.phoneme_offsets_global != 0).sum(1).long(), ds.word_lengths)
 
 
 def test_slice_name():

--- a/test/generators/test_stimulus.py
+++ b/test/generators/test_stimulus.py
@@ -28,7 +28,8 @@ def _basic_draw_and_assert(abstract_generator, word_lengths, max_num_phonemes, *
     assert torch.all(word_onsets[1:] >= word_onsets[:-1])
 
     # Test that the phoneme onsets are in the correct order
-    assert torch.all(phoneme_onsets_global[:, 1:] >= phoneme_onsets_global[:, :-1])
+    over_length_mask = torch.arange(max_num_phonemes) >= word_lengths.unsqueeze(1)
+    assert torch.all(over_length_mask[:, 1:] | (phoneme_onsets_global[:, 1:] >= phoneme_onsets_global[:, :-1]))
 
     return phoneme_onsets, phoneme_onsets_global, word_onsets, word_offsets
 


### PR DESCRIPTION
…tests on phoneme onset/offset representation, and also enforce assumptions at runtime with `BerpDataset.check_preconditions`


I verified that there is no difference in test performance with the converged models (modulo the other bug we discovered re: mismatch in confusion matrix semantics due to mismatch in phoneme ordering; this was fixed in #14).